### PR TITLE
fix(ime): no preedit when unfocused

### DIFF
--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -24,6 +24,7 @@ pub fn main() -> iced::Result {
             size: (500, 800),
             ..window::Settings::default()
         },
+        default_font: Some(include_bytes!("../fonts/NanumGothic.ttf")),
         ..Settings::default()
     })
 }

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -797,6 +797,10 @@ where
         Event::Keyboard(keyboard::Event::IMEPreedit(text)) => {
             let state = state();
 
+            if !state.is_focused {
+                return event::Status::Ignored;
+            }
+
             let cursor_offset = state.cursor.start(value);
 
             // limit borrow life time.


### PR DESCRIPTION
I added cjk font for the test. Should I remove code and binary?